### PR TITLE
Edits to Seb's changes

### DIFF
--- a/bin/workflows/pycbc_create_bank_verifier_workflow
+++ b/bin/workflows/pycbc_create_bank_verifier_workflow
@@ -39,10 +39,10 @@ from pycbc.workflow import PycbcCreateInjectionsExecutable
 from pycbc.workflow import setup_splittable_dax_generated
 
 # Boiler-plate stuff
-__author__  = "Ian Harry <ian.harry@ligo.org> and \
-Sebastian Khan <sebastian.khan@ligo.org>"
+__author__ = "Ian Harry <ian.harry@ligo.org> and "
+__author__ += "Sebastian Khan <sebastian.khan@ligo.org>"
 __version__ = pycbc.version.git_verbose_msg
-__date__    = pycbc.version.date
+__date__ = pycbc.version.date
 __program__ = "pycbc_create_bank_verifier_workflow"
 
 # Some new executable classes. These can be moved into modules if needed
@@ -194,58 +194,50 @@ inp_bank.ifo_list=(['H1','L1','V1'])
 inp_bank.segment = workflow.analysis_time
 
 # Injection Job
-# determine which executable will be used to generate injections
-injection_generator = workflow.cp.get('workflow', 'injection-generator')
+injection_exe = workflow.cp.get('executables', 'injection')
+injection_exe = os.path.basename(injection_exe)
+logging.info("Using {} for injection generation.".format(injection_exe))
 
-# these names are the fields in ini file that point to the executable also.
-supported_injection_generators = ['inspinj_injection', 'pycbc_injection']
-
-if injection_generator not in supported_injection_generators:
-    err_msg = """'injection-generator = {}' is not supported. \
-Please choose from = {}
-""".format(injection_generator,supported_injection_generators)
-    raise ValueError(err_msg)
-logging.info("Running with injection_generator = {}".format(injection_generator))
-
-if injection_generator == "inspinj":
+if injection_exe == "lalapps_inspinj":
     injection_job = LalappsInspinjExecutable(workflow.cp,
-        injection_generator, out_dir='.', ifos='HL', tags=[])
-elif injection_generator == "pycbc_injection":
+        'injection', out_dir='.', ifos='HL', tags=[])
+elif injection_exe == "pycbc_create_injections":
     injection_job = PycbcCreateInjectionsExecutable(
-        workflow.cp, injection_generator, out_dir=".", ifo="HL", tags=[])
+        workflow.cp, 'injection', out_dir=".", ifo="HL", tags=[])
+else:
+    err_msg = "Injection executable {} is not supported.".format(injection_exe)
+    err_msg += " Please use, lalapps_inspinj or pycbc_create_injections."
+    raise ValueError(err_msg)
 
-def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks,
-                    injection_generator):
+
+def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks):
     """Add a group of jobs that does a complete banksim.
     """
-    if injection_generator == "pycbc_injection":
-        # had to put this near the top of this function
-        # so othat num_injs would get set in the dax for all cases.
-        # some voodoo.
-        workflow.cp.set("pycbc_injection", "ninjections", num_injs)
-
     # curr_tags are like [section_heading, injection_set_name]
     injection_job.update_current_tags(curr_tags)
 
     start_time = 1000000000
     end_time = 1000000000+int(num_injs)
 
-    if injection_generator == "inspinj":
-
+    if injection_exe == "lalapps_inspinj":
         t_seg = segments.segment([start_time, end_time])
         node = injection_job.create_node(t_seg)
         inj_file = node.output_file
 
-    elif injection_generator == "pycbc_injection":
-
-        inj_file_ext = workflow.cp.get("pycbc_injection-extra", "output-file-format")
-        injection_config_file = workflow.cp.get("pycbc_injection"+"-"+curr_tags[1], "config-file")
-        injection_cp = wf.File.from_path(injection_config_file)
-        node, inj_file = \
-            injection_job.create_node(config_file=injection_cp,
-                                      ext=inj_file_ext,
-                                      start_time=start_time,
-                                      end_time=end_time)
+    elif injection_exe == "pycbc_create_injections":
+        # Set a default value. When .hdf is supported this should be .hdf
+        inj_file_ext = ".xml"
+        # Allow overrides from config file
+        if workflow.cp.has_option_tags("workflow-injection",
+                                       "output-file-format", curr_tags):
+            inj_file_ext = workflow.cp.get_option_tags("workflow-injection",
+                                                       "output-file-format",
+                                                       curr_tags)
+        node = injection_job.create_node(ext=inj_file_ext,
+                                         start_time=start_time,
+                                         end_time=end_time,
+                                         num_injs=num_injs)
+        inj_file = node.output_file
 
     workflow += node
     split_injs = setup_splittable_dax_generated(workflow, [inj_file],
@@ -269,9 +261,6 @@ def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks,
         currinj_banksim_files = wf.FileList([])
         for bank_idx, split_bank in enumerate(split_banks):
             bank_tag = 'BANK{}'.format(bank_idx)
-            # does this need to be here?
-            # seems redundent with a few lines above.
-            inj_tag = 'INJ{}'.format(inj_idx)
             node = banksim_job.create_node(workflow.analysis_time, split_inj,
                                            split_bank,
                                            extra_tags=[bank_tag,inj_tag])
@@ -297,7 +286,7 @@ for file_tag, num_injs in workflow.cp.items('workflow-pointinjs'):
     curr_tags = ['shortinjs', file_tag]
     logging.info("working curr_tags = {}".format(curr_tags))
     curr_file = add_banksim_set(workflow, file_tag, num_injs, curr_tags,
-                                split_banks, injection_generator)
+                                split_banks)
     output_pointinjs[file_tag] = curr_file
 
 curr_tags = ['broadinjbanksplit']
@@ -309,7 +298,7 @@ for file_tag, num_injs in workflow.cp.items('workflow-broadinjs'):
     curr_tags = ['broadinjs', file_tag]
     logging.info("working curr_tags = {}".format(curr_tags))
     curr_file = add_banksim_set(workflow, file_tag, num_injs, curr_tags,
-                                split_banks, injection_generator)
+                                split_banks)
     output_broadinjs[file_tag] = curr_file
 
 plotting_nodes = []

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1622,8 +1622,7 @@ class PycbcCreateInjectionsExecutable(Executable):
     """
 
     current_retention_level = Executable.ALL_TRIGGERS
-    # This might be plural i.e. "--config-files"
-    file_input_options = ["--config-file"]
+    file_input_options = ["--config-files"]
     def __init__(self, cp, exe_name, ifo=None, out_dir=None,
                  universe=None, tags=None):
         super(PycbcCreateInjectionsExecutable, self).__init__(

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1629,15 +1629,12 @@ class PycbcCreateInjectionsExecutable(Executable):
         super(PycbcCreateInjectionsExecutable, self).__init__(
                                cp, exe_name, universe, ifo, out_dir, tags)
 
-    def create_node(self, config_file=None, seed=None, tags=None, ext=".hdf",
-                    start_time=None, end_time=None):
+    def create_node(self, seed=None, tags=None, ext=".hdf",
+                    start_time=None, end_time=None, num_injs=None):
         """ Set up a CondorDagmanNode class to run ``pycbc_create_injections``.
 
         Parameters
         ----------
-        config_file : pycbc.workflow.core.File
-            A ``pycbc.workflow.core.File`` for inference configuration file
-            to be used with ``--config-files`` option.
         seed : int
             Seed to use for generating injections.
         tags : list
@@ -1652,6 +1649,12 @@ class PycbcCreateInjectionsExecutable(Executable):
         end_time : int
             Use this to override the value of the 'end-time' given in
             the 'config_file' [workflow] section
+            ( Default = None )
+        num_injs : int
+            Use this to specify the number of injections (the --ninjections
+            command line argument). If not provided (or set to None), this
+            command line argument is not set and it is assumed this will be
+            specified in the configuration file.
             ( Default = None )
 
         Returns
@@ -1670,16 +1673,18 @@ class PycbcCreateInjectionsExecutable(Executable):
             end_time = self.cp.get("workflow", "end-time")
         analysis_time = segments.segment(int(start_time), int(end_time))
 
+        if num_injs is not None:
+            node.add_opt("--ninjections", num_injs)
+
         # make node for running executable
         node = Node(self)
-        # node.add_input_opt("--config-file", config_file)
         if seed:
             node.add_opt("--seed", seed)
         injection_file = node.new_output_file_opt(analysis_time,
                                                   ext, "--output-file",
                                                   tags=tags)
 
-        return node, injection_file
+        return node
 
 class PycbcInferenceExecutable(Executable):
     """ The class responsible for creating jobs for ``pycbc_inference``.


### PR DESCRIPTION
Hi @Cyberface here are some changes to either simplify in a few cases, or to follow convention in others, your patch.

I'm a little confused as to how the config files were being parsed to `pycbc_create_injections` at all before, because `--config-files` was not identified as a command line option. I also realized that `--config-files` might be a list of files, which requires a separate fix:

https://github.com/gwastro/pycbc/pull/2335

to `workflow.core` to handle that. Please pick this patch up if trying to send multiple config files to the create_injections job. Let's discuss on Slack in cases where this isn't clear.